### PR TITLE
ged esta_pronto_para_assinar, melhorias gerencia modelo

### DIFF
--- a/src/djdocuments/djdocuments_urls.py
+++ b/src/djdocuments/djdocuments_urls.py
@@ -106,6 +106,10 @@ urlpatterns = [
         login_required(documentos_views.AssinaturasRealizadasPorGrupo.as_view()),
         name='assinados'
         ),
+    url(r'^d/marcardesmarcarprontoparaassinar/(?P<slug>\b[0-9A-Fa-f]{8}\b(-\b[0-9A-Fa-f]{4}\b){3}-\b[0-9A-Fa-f]{12}\b)/$',
+        login_required(documentos_views.DocumentoMarcarDesmarcarProntoParaAssinar.as_view()),
+        name='marcardesmarcar_pronto_para_assinar'
+        ),
     url(r'^d/(?P<slug>\b[0-9A-Fa-f]{8}\b(-\b[0-9A-Fa-f]{4}\b){3}-\b[0-9A-Fa-f]{12}\b)/assinaturas/$',
         login_required(documentos_views.DocumentoAssinaturasListView.as_view()),
         name='assinaturas'

--- a/src/djdocuments/forms.py
+++ b/src/djdocuments/forms.py
@@ -579,3 +579,16 @@ class TipoDocumentoForm(BootstrapFormInputMixin, forms.ModelForm):
     class Meta:
         model = TipoDocumento
         fields = '__all__'
+
+
+class DocumentoMarcarDesmarcarProntoParaAssinarForm(forms.ModelForm):
+    esta_pronto_para_assinar = forms.BooleanField(label='', widget=forms.HiddenInput, required=False)
+
+    class Meta:
+        model = Documento
+        fields = (
+            'esta_pronto_para_assinar',
+        )
+        # widgets = {
+        #     'esta_pronto_para_assinar': forms.HiddenInput()
+        # }

--- a/src/djdocuments/models.py
+++ b/src/djdocuments/models.py
@@ -646,6 +646,13 @@ class Documento(SoftDeletableModel):
             url = reverse('documentos:finalizar_assinatura', kwargs={'slug': self.pk_uuid})
         return url
 
+    @property
+    def get_pronto_para_assinar_url(self):
+        url = '#'
+        if not self.eh_modelo and not self.esta_assinado:
+            url = reverse('documentos:marcardesmarcar_pronto_para_assinar', kwargs={'slug': self.pk_uuid})
+        return url
+
     _desabilitar_temporiariamente_versao_numero = False
 
     def save(self, *args, **kwargs):

--- a/src/djdocuments/templates/luzfcb_djdocuments/django_form_content.html
+++ b/src/djdocuments/templates/luzfcb_djdocuments/django_form_content.html
@@ -15,9 +15,12 @@
                                         </div>
                                     {% endif %}
                                     {% for form_field in form %}
+                                      {% if form_field.is_hidden  %}
+                                          {{ form_field }}
+                                      {% else %}
                                         <div class="form-group {% if form_field.errors %}has-error{% endif %}">
                                             <label for="{{ form_field.id_for_label }}"
-                                                   class="col-sm-2 control-label">{{ form_field.label }}:</label>
+                                                   class="col-sm-2 control-label">{{ form_field.label }}-----:</label>
                                             <div class="col-sm-10">
                                                 {{ form_field }}
 
@@ -36,4 +39,5 @@
                                                 </span>
                                             </div>
                                         </div>
+                                      {% endif %}
                                     {% endfor %}

--- a/src/djdocuments/templates/luzfcb_djdocuments/django_form_content_boostrap2.html
+++ b/src/djdocuments/templates/luzfcb_djdocuments/django_form_content_boostrap2.html
@@ -15,29 +15,33 @@
                                         </div>
                                     {% endif %}
                                     {% for form_field in form %}
-                                        <div style="height:10px;">
-                                        </div>
-                                        <div class="control-group form-group row-fluid {% if form_field.errors %}error has-error{% endif %} ">
-                                            <label for="{{ form_field.id_for_label }}"
-                                                   class="span2 col-sm-2 control-label">{{ form_field.label }}:</label>
-                                            <div class="span10 col-sm-12">
-                                                {{ form_field }}
+                                      {% if form_field.is_hidden  %}
+                                          {{ form_field }}
+                                      {% else %}
+                                          <div style="height:10px;">
+                                          </div>
+                                          <div class="control-group form-group row-fluid {% if form_field.errors %}error has-error{% endif %} ">
+                                              <label for="{{ form_field.id_for_label }}"
+                                                     class="span2 col-sm-2 control-label">{{ form_field.label }}:</label>
+                                              <div class="span10 col-sm-12">
+                                                  {{ form_field }}
 
-                                                <div id="helpBlock2">
-                                                    {% if form_field.errors %}
-                                                        {% for error in form_field.errors %}
-                                                            <p id="error_{{ forloop.counter }}_{{ form_field.auto_id }}"
-                                                               class="help-inline help-block">
-                                                                <strong>{{ error|escape }}</strong></p>
-                                                        {% endfor %}
-                                                    {% endif %}
-                                                    {% if form_field.help_text %}
-                                                        <div class="help-inline help-block">
-                                                        <p id="hint_{{ form_field.auto_id }}"
-                                                           >{{ form_field.help_text|safe }}</p>
-                                                        </div>
-                                                    {% endif %}
-                                                </div>
-                                            </div>
-                                        </div>
+                                                  <div id="helpBlock2">
+                                                      {% if form_field.errors %}
+                                                          {% for error in form_field.errors %}
+                                                              <p id="error_{{ forloop.counter }}_{{ form_field.auto_id }}"
+                                                                 class="help-inline help-block">
+                                                                  <strong>{{ error|escape }}</strong></p>
+                                                          {% endfor %}
+                                                      {% endif %}
+                                                      {% if form_field.help_text %}
+                                                          <div class="help-inline help-block">
+                                                          <p id="hint_{{ form_field.auto_id }}"
+                                                             >{{ form_field.help_text|safe }}</p>
+                                                          </div>
+                                                      {% endif %}
+                                                  </div>
+                                              </div>
+                                          </div>
+                                      {% endif %}
                                     {% endfor %}

--- a/src/djdocuments/templates/luzfcb_djdocuments/documento_marcardesmarcar_pronto_para_assinar.html
+++ b/src/djdocuments/templates/luzfcb_djdocuments/documento_marcardesmarcar_pronto_para_assinar.html
@@ -4,19 +4,18 @@
 
 
 {% block form_section %}
-    {#    {% if form %}#}
-
     <div class="panel panel-info">
-        <div class="panel-heading">Liberar documento para coleta de assinaturas</div>
+        <div class="panel-heading">{{ msg_header }}</div>
         <div class="panel-body">
             <form class="form-horizontal" method="post" action="{{ form_action }}">
                 <fieldset>
-                    <legend>Tem certeza que deseja liberar para coleta de assinaturas?
+                    <legend>
+                      {{ msg }}
                     </legend>
                     {% include "luzfcb_djdocuments/django_form_content.html" with form=form %}
                     <div class="form-group">
                         <div class="col-sm-offset-2 col-sm-10">
-                            <button type="submit" class="btn btn-success">Liberar</button>
+                            <button type="submit" class="btn btn-success">{{ msg_botao_submit }}</button>
                         </div>
                     </div>
                 </fieldset>

--- a/src/djdocuments/templates/luzfcb_djdocuments/documento_marcardesmarcar_pronto_para_assinar.html
+++ b/src/djdocuments/templates/luzfcb_djdocuments/documento_marcardesmarcar_pronto_para_assinar.html
@@ -1,0 +1,41 @@
+{% extends "luzfcb_djdocuments/documento_assinar_base.html" %}
+{% load luzfcb_djdocuments_tags %}
+
+
+
+{% block form_section %}
+    {#    {% if form %}#}
+
+    <div class="panel panel-info">
+        <div class="panel-heading">Liberar documento para coleta de assinaturas</div>
+        <div class="panel-body">
+            <form class="form-horizontal" method="post" action="{{ form_action }}">
+                <fieldset>
+                    <legend>Tem certeza que deseja liberar para coleta de assinaturas?
+                    </legend>
+                    {% include "luzfcb_djdocuments/django_form_content.html" with form=form %}
+                    <div class="form-group">
+                        <div class="col-sm-offset-2 col-sm-10">
+                            <button type="submit" class="btn btn-success">Liberar</button>
+                        </div>
+                    </div>
+                </fieldset>
+            </form>
+
+        </div>
+    </div>
+
+
+
+
+{% endblock form_section %}
+{% block js_app %}
+
+
+    {% if form %}
+        {{ form.media }}
+    {% endif %}
+
+{% endblock js_app %}
+
+

--- a/src/djdocuments/templates/luzfcb_djdocuments/documento_marcardesmarcar_pronto_para_assinar_ajax.html
+++ b/src/djdocuments/templates/luzfcb_djdocuments/documento_marcardesmarcar_pronto_para_assinar_ajax.html
@@ -1,0 +1,25 @@
+{% extends 'luzfcb_djdocuments/base_ajax_modal_response.html' %}
+{% load luzfcb_djdocuments_tags %}
+
+{% block modal_header_content %}
+    <h3>
+      Liberar para coleta de assinaturas
+    </h3>
+    Ao liberar, este documento ficará disponivel paras as Defensorias assinarem.
+{% endblock modal_header_content %}
+
+{% block modal_body_header %}
+
+  <table>
+    <tr>
+      <td>Número: <b>{{ object.identificador_versao }}</b></td>
+    </tr>
+    <tr>
+      <td>Assunto: <b>"{{ object.assunto|remover_tags_html }}"</b></td>
+    </tr>
+  </table>
+
+{% endblock modal_body_header %}
+
+{% block submit_text %}Liberar{% endblock submit_text %}
+

--- a/src/djdocuments/templates/luzfcb_djdocuments/documento_marcardesmarcar_pronto_para_assinar_ajax.html
+++ b/src/djdocuments/templates/luzfcb_djdocuments/documento_marcardesmarcar_pronto_para_assinar_ajax.html
@@ -3,9 +3,9 @@
 
 {% block modal_header_content %}
     <h3>
-      Liberar para coleta de assinaturas
+      {{ msg_header }}
     </h3>
-    Ao liberar, este documento ficará disponivel paras as Defensorias assinarem.
+    {{ msg }}
 {% endblock modal_header_content %}
 
 {% block modal_body_header %}
@@ -21,5 +21,5 @@
 
 {% endblock modal_body_header %}
 
-{% block submit_text %}Liberar{% endblock submit_text %}
+{% block submit_text %}{{ msg_botao_submit }}{% endblock submit_text %}
 

--- a/src/djdocuments/templates/luzfcb_djdocuments/documento_validacao_detail.html
+++ b/src/djdocuments/templates/luzfcb_djdocuments/documento_validacao_detail.html
@@ -197,12 +197,20 @@
                                 </div>
                                 <div id="acoes">
                                     <hr>
-                                    {% if pode_editar %}
+                                    {% if pode_editar and not object.esta_pronto_para_assinar %}
                                         <a href="{{ object.get_edit_url }}" class="btn btn-sm btn-primary"><span
                                                 class="glyphicon glyphicon-pencil"
                                                 aria-hidden="true"></span> Editar
                                             documento</a>
-
+                                    {% elif pode_editar and object.esta_pronto_para_assinar %}
+                                        <a href="{{ object.get_pronto_para_assinar_url }}"
+                                           class="btn btn-sm btn-primary"
+                                           data-ajaxmodal="true"
+                                           data-ajaxmodal-prefetch="true"
+                                        ><span
+                                                class="glyphicon glyphicon-pencil"
+                                                aria-hidden="true"></span> Desbloquear para edição
+                                        </a>
                                     {% endif %}
                                     {% if object.pronto_para_finalizar %}
                                         <a href="{{ object.get_finalizar_url }}"
@@ -213,6 +221,20 @@
                                                 class="glyphicon glyphicon-pencil"
 
                                                 aria-hidden="true"></span> Finalizar</a>
+                                    {% endif %}
+                                    {% if pode_adicionar_assinantes %}
+{#                                        <small class="pull-right">#}
+                                            <a
+                                                    href="{{ object.get_adicionar_assinante_url }}"
+                                                    data-ajaxmodal="true"
+                                                    data-ajaxmodal-prefetch="true"
+                                                    class="btn btn-sm btn-primary adicionar_assinantes"
+                                                    {#                                                data-toggle="modal"#}
+                                                    {#                                                data-target=".adicionar_assinantes_modal"#}
+                                            >
+                                                Adicionar assinantes
+                                            </a>
+{#                                        </small>#}
                                     {% endif %}
                                 </div>
                                 {% if not object.eh_modelo %}
@@ -250,22 +272,7 @@
                                     <hr>
                                     <div id="sua_assinatura">
 
-                                        <h4>
-                                            <b>Suas assinaturas</b>
-                                            {% if pode_adicionar_assinantes %}
-                                                <small class="pull-right">
-                                                    <a
-                                                            href="{{ object.get_adicionar_assinante_url }}"
-                                                            data-ajaxmodal="true"
-                                                            data-ajaxmodal-prefetch="true"
-                                                            class="btn-link adicionar_assinantes"
-                                                            {#                                                data-toggle="modal"#}
-                                                            {#                                                data-target=".adicionar_assinantes_modal"#}
-                                                    >
-                                                        Adicionar assinantes</a>
-                                                </small>
-                                            {% endif %}
-                                        </h4>
+
                                         {% regroup assinaturas_pendentes_dos_meus_grupos by grupo_assinante_nome as minhas_assinaturas_pendentes %}
                                         {% for minha in minhas_assinaturas_pendentes %}
                                             {% if forloop.first %}
@@ -286,7 +293,8 @@
                                                                 {% else %}
                                                                     <span style="opacity: 0.0;">----</span>
                                                                 {% endif %}
-                                                                <div class="pull-right">
+                                                                {% if object.esta_pronto_para_assinar %}
+                                                                  <div class="pull-right">
                                                                     <div class="btn-group btn-group-xs" role="group">
 
                                                                         <a href="{{ assinatura.get_url_para_assinar }}"
@@ -296,6 +304,7 @@
                                                                             <em class="glyphicon glyphicon-edit"></em>
                                                                             Assinar
                                                                         </a>
+                                                                        {% if eh_ultimo_pendente %}
                                                                         <a href="{{ assinatura.get_url_para_assinar_e_finalizar }}"
                                                                            data-ajaxmodal="true"
                                                                            data-ajaxmodal-prefetch="true"
@@ -303,7 +312,8 @@
                                                                             <em class="glyphicon glyphicon-edit"></em>
                                                                             Assinar e Finalizar
                                                                         </a>
-                                                                        {% if pode_remover_assinantes and not assinatura.esta_assinado %}
+                                                                        {% endif %}
+                                                                        {% if pode_remover_assinantes and not assinatura.esta_assinado and not assinatura.grupo_assinante_id == object.grupo_dono_id %}
                                                                             <a href="{{ assinatura.get_url_para_remover }}"
                                                                                data-ajaxmodal="true"
                                                                                data-ajaxmodal-prefetch="true"
@@ -313,7 +323,7 @@
                                                                                       data-container="#popover-modelo"
                                                                                       data-toggle="popover"
                                                                                       data-trigger="focus"
-                                                                                      data-content="Clique para remover esta pendência de assinatura">
+                                                                                      data-content="Remover assinante">
                                                                                     <em class="glyphicon glyphicon-trash"></em>
                                                                                 </span>
                                                                             </a>
@@ -321,7 +331,7 @@
                                                                     </div>
 
                                                                 </div>
-
+                                                                {% endif %}
                                                             </li>
 
                                                         {% endfor %}
@@ -340,37 +350,49 @@
                                             <ul class="list-unstyled">
                                                 <li>
                                                     <strong>
-                                                        {{ minha.grouper }}:
+                                                        {{ minha.grouper }}
                                                     </strong>
                                                     <ul class="list-unstyled">
                                                         {% for assinatura in minha.list %}
                                                             <li>
                                                                 {% if assinatura.esta_assinado %}
-                                                                    <span tabindex="0" class="" role="button"
-                                                                          data-container="#popover-modelo"
-                                                                          data-toggle="popover" data-trigger="focus"
-                                                                          data-content="Assinatura efetivada em {{ assinatura.assinado_em }}"
-                                                                    >
-                                                                                {{ assinatura.assinado_nome }}
-                                                                            </span>
+                                                                  <span class="label label-success">Assinado</span>
+                                                                  <small class="text-muted">
+                                                                    por <span tabindex="0" class=""
+                                                                                       role="button"
+                                                                                       data-container="#popover-modelo"
+                                                                                       data-toggle="popover"
+                                                                                       data-trigger="focus"
+                                                                                       data-content="{{ assinatura.assinado_nome }}"
+                                                                  >{{ assinatura.assinado_por.username }}</span>
+                                                                    em {{ assinatura.assinado_em|date:'d/m/Y H:i' }}
+                                                                  </small>
+
                                                                 {% else %}
-                                                                    {#                                                                <span class="label label-danger">Pendente</span>#}
-                                                                    {{ assinatura.assinado_nome }}
+                                                                    {#                                                               <span class="label label-danger">Pendente</span>#}
+                                                                   <small class="text-muted">
+                                                                   {{ assinatura.assinado_nome }}
+                                                                  </small>
                                                                 {% endif %}
 
                                                                 {% if pode_remover_assinantes and not assinatura.esta_assinado %}
-                                                                    <small class="pull-right">
-                                                                    <span tabindex="0" class="" role="button"
-                                                                          data-container="#popover-modelo"
-                                                                          data-toggle="popover" data-trigger="focus"
-                                                                          data-content="Clique para remover esta pendência de assinatura"
-                                                                    >
-                                                                        <a href="{{ assinatura.get_url_para_remover }}"
-                                                                           data-ajaxmodal="true"
-                                                                           data-ajaxmodal-prefetch="true"
-                                                                        >X</a>
-                                                                    </span>
-                                                                    </small>
+                                                                    <div class="pull-right">
+                                                                      <div  class="btn-group btn-group-xs" role="group">
+                                                                            <a href="{{ assinatura.get_url_para_remover }}"
+                                                                               data-ajaxmodal="true"
+                                                                               data-ajaxmodal-prefetch="true"
+                                                                               class="btn btn-danger" type="button">
+                                                                                <span tabindex="0"
+                                                                                      role="button"
+                                                                                      data-container="#popover-modelo"
+                                                                                      data-toggle="popover"
+                                                                                      data-trigger="focus"
+                                                                                      data-content="Remover assinante">
+                                                                                    <em class="glyphicon glyphicon-trash"></em>
+                                                                                </span>
+                                                                            </a>
+                                                                      </div>
+                                                                    </div>
                                                                 {% endif %}
                                                             </li>
                                                         {% endfor %}
@@ -385,7 +407,7 @@
                                             {% if forloop.first %}
                                                 <hr>
                                                 <div>
-                                                <h4><b>Demais assinaturas</b>
+                                                <h4><b>Demais assinantes</b>
                                                     <small class="pull-right">
                                                         {#                                                <a href="#">Ver detalhes</a>#}
                                                     </small>
@@ -402,32 +424,42 @@
                                                     {% for assinatura in minha.list %}
                                                         <li>
                                                             {% if assinatura.esta_assinado %}
-                                                                <span class="label label-success">Realizada</span>
-                                                                <span tabindex="0" class="" role="button"
-                                                                      data-container="#popover-modelo"
-                                                                      data-toggle="popover" data-trigger="focus"
-                                                                      data-content="Assinatura efetivada em {{ assinatura.assinado_em }}"
-                                                                >
-                                                                                {{ assinatura.assinado_nome }}
-                                                                            </span>
+                                                                <span class="label label-success">Assinado</span>
+                                                                  <small class="text-muted">
+                                                                    por <span tabindex="0" class=""
+                                                                                       role="button"
+                                                                                       data-container="#popover-modelo"
+                                                                                       data-toggle="popover"
+                                                                                       data-trigger="focus"
+                                                                                       data-content="{{ assinatura.assinado_nome }}"
+                                                                  >{{ assinatura.assinado_por.username }}</span>
+                                                                    em {{ assinatura.assinado_em|date:'d/m/Y H:i' }}
+                                                                  </small>
                                                             {% else %}
                                                                 <span class="label label-danger">Pendente</span>
+                                                              <small class="text-muted">
                                                                 {{ assinatura.assinado_nome }}
+                                                              </small>
                                                             {% endif %}
 
                                                             {% if pode_remover_assinantes and not assinatura.esta_assinado %}
-                                                                <small class="pull-right">
-                                                                    <span tabindex="0" class="" role="button"
-                                                                          data-container="#popover-modelo"
-                                                                          data-toggle="popover" data-trigger="focus"
-                                                                          data-content="Clique para remover esta pendência de assinatura"
-                                                                    >
-                                                                        <a href="{{ assinatura.get_url_para_remover }}"
-                                                                           data-ajaxmodal="true"
-                                                                           data-ajaxmodal-prefetch="true"
-                                                                        >X</a>
-                                                                    </span>
-                                                                </small>
+                                                                    <div class="pull-right">
+                                                                      <div  class="btn-group btn-group-xs" role="group">
+                                                                            <a href="{{ assinatura.get_url_para_remover }}"
+                                                                               data-ajaxmodal="true"
+                                                                               data-ajaxmodal-prefetch="true"
+                                                                               class="btn btn-danger" type="button">
+                                                                                <span tabindex="0"
+                                                                                      role="button"
+                                                                                      data-container="#popover-modelo"
+                                                                                      data-toggle="popover"
+                                                                                      data-trigger="focus"
+                                                                                      data-content="Remover assinante">
+                                                                                    <em class="glyphicon glyphicon-trash"></em>
+                                                                                </span>
+                                                                            </a>
+                                                                      </div>
+                                                                    </div>
                                                             {% endif %}
                                                         </li>
                                                     {% endfor %}

--- a/src/djdocuments/templates/luzfcb_djdocuments/editor/documento_editor.html
+++ b/src/djdocuments/templates/luzfcb_djdocuments/editor/documento_editor.html
@@ -75,7 +75,7 @@
                         </div>
                         <div class="btn-group">
 
-                            <button class="btn btn-default" type="button" id="salvar">
+                            <button class="btn btn-success" type="button" id="salvar">
                                 <em class="glyphicon glyphicon-floppy-disk"></em> Salvar
                             </button>
                             {% if object %}
@@ -100,6 +100,16 @@
                                     <a href="{{ object.get_preview_url }}"
                                        class="btn btn-default"
                                     ><em class="icofont-search"></em>Visualizar</a>
+                                    <a
+                                       href="{% url 'documentos:marcardesmarcar_pronto_para_assinar' slug=object.pk_uuid %}?initial=True"
+                                       class="btn btn-default"
+                                       id="btn-liberar-para-assinatura"
+                                       data-ajaxmodal="true"
+                                       data-ajaxmodal-prefetch="true"
+                                       data-sucess-url="{{ object.get_preview_url }}"
+                                    >
+                                      <em class="icofont-search"></em>Liberar para assinatura
+                                    </a>
 {#                                    {% url 'documentos:assinaturas' slug=object.pk_uuid as documento_assinaturas %}#}
 {#                                    <a href="{{ documento_assinaturas }}"#}
 {#                                       class="btn btn-default"#}

--- a/src/djdocuments/templates/luzfcb_djdocuments/painel_geral_modelos.html
+++ b/src/djdocuments/templates/luzfcb_djdocuments/painel_geral_modelos.html
@@ -102,9 +102,18 @@
                         </small>
                     </td>
                     <td>
-                        <small rel="tooltip" data-original-title="{{ dado.grupo_dono }}">
+                        {% if dado.grupo_dono %}
+                          <small rel="tooltip" data-original-title="{{ dado.grupo_dono }}">
                             {{ dado.grupo_dono|truncatechars:36 }}
-                        </small>
+                          </small>
+
+                        {% else %}
+                          <small rel="tooltip" data-original-title="Modelo Global">
+                            Modelo Global
+                          </small>
+
+                        {% endif %}
+
                     </td>
                     <td>
                         <small rel="tooltip" data-original-title="{{ dado.criado_por_nome }}">
@@ -126,6 +135,7 @@
                         <div>
                           <div class="form-group ">
                             <div class="col-sm-10">
+                            {% if dado.grupo_dono or user.is_superuser %}
                               <input name="modelo_pronto_para_utilizacao"
                                      class="modelo_pronto_para_utilizacao"
                                      type="checkbox"
@@ -136,6 +146,7 @@
                                      data-onstyle="success"
                                      data-size="small"
                               >
+                            {% endif %}
                             </div>
                           </div>
                         </div>
@@ -145,10 +156,12 @@
                            {% spurl base=dado.get_preview_url query='next={{ next_success_url }}' as url_para_visualizar_com_query %}
                             <a href="{{ url_para_visualizar_com_query }}" class="btn-link">
                                 <i class="icofont-search"></i> Visualizar
-                            </a> |
-                            <a href="{{ dado.get_edit_url }}" class="btn-link">
-                                <i class="elusive-file-edit"></i> Editar
                             </a>
+                            {% if dado.grupo_dono or user.is_superuser %}|
+                              <a href="{{ dado.get_edit_url }}" class="btn-link">
+                                <i class="elusive-file-edit"></i> Editar
+                              </a>
+                            {% endif %}
                         </div>
                     </td>
                 </tr>


### PR DESCRIPTION
* modelos globais so podem ser editados por is_superuser. 
* Documentos agora somente apareceram como pendente de assinatura, se devidamente marcados como pronto_para_assinar=True. 
* Adicionado count para todas as queries da view DocumentoPainelGeralPorGrupoView 
* Adicionado queries para documentos pronto_para_assinar=False e Documentos assinados e finalizados.